### PR TITLE
Let user know what's wrong when Web Bluetooth API is missing

### DIFF
--- a/bluetooth-toy-bb8/index.html
+++ b/bluetooth-toy-bb8/index.html
@@ -121,6 +121,12 @@ limitations under the License.
           </div>
         </paper-card>
 
+        <paper-dialog id="no-bluetooth">
+          <h2>No Web Bluetooth</h2>
+          <p>The Web Bluetooth API is missing. Please enable it at
+          chrome://flags/#enable-web-bluetooth and try again.</p>
+        </paper-dialog>
+
         <paper-dialog id="dialog">
           <h2>Error</h2>
           <p>Could not connect to bluetooth device!</p>
@@ -168,6 +174,10 @@ limitations under the License.
         let heading = 0;
         let busy = false;
         progress.hidden = true;
+
+        if (navigator.bluetooth == undefined) {
+          document.getElementById("no-bluetooth").style.display = "block";
+        }
 
         function handleError(error) {
           console.log(error);

--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!doctype html>
 <h1>Web Bluetooth Demos</h1>
 <ul>
-  <li><a href="https://webbluetoothcg.github.io/demos/bluetooth-toy-plane/">bluetooth-toy-plane</a></li>
-  <li><a href="https://webbluetoothcg.github.io/demos/heart-rate-sensor/">heart-rate-sensor</a></li>
-  <li><a href="https://webbluetoothcg.github.io/demos/playbulb-candle/">playbulb-candle</a></li>
-  <li><a href="https://webbluetoothcg.github.io/demos/bluetooth-printer/">bluetooth-printer</a></li>
-  <li><a href="https://webbluetoothcg.github.io/demos/bluetooth-toy-bb8/">bluetooth-toy-bb8</a></li>
+  <li><a href="./bluetooth-toy-plane/">bluetooth-toy-plane</a></li>
+  <li><a href="./heart-rate-sensor/">heart-rate-sensor</a></li>
+  <li><a href="./playbulb-candle/">playbulb-candle</a></li>
+  <li><a href="./bluetooth-printer/">bluetooth-printer</a></li>
+  <li><a href="./bluetooth-toy-bb8/">bluetooth-toy-bb8</a></li>
 </ul>

--- a/playbulb-candle/app.js
+++ b/playbulb-candle/app.js
@@ -109,3 +109,15 @@ function onColorChanged(rgb) {
   }
 }
 
+window.onload = function() {
+  var connect = document.getElementById("connect");
+  var no_bt = document.getElementById("no-bluetooth");
+  if (navigator.bluetooth == undefined) {
+    console.log("No navigator.bluetooth found.");
+    connect.style.display = "none";
+    no_bt.style.display = "block";
+  } else {
+    connect.style.display = "block";
+    no_bt.style.display = "none";
+  }
+};

--- a/playbulb-candle/index.html
+++ b/playbulb-candle/index.html
@@ -14,8 +14,19 @@
   <body id="state">
     <div id="step1">
       <div id="title">PLAYBULB CANDLE DEMO</div>
-      <button id="connect" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">CONNECT</button>
-    </div>
+      <button id="connect" class="mdl-button mdl-js-button
+    mdl-button--raised mdl-js-ripple-effect mdl-button--accent"
+      style="display:none">CONNECT</button>
+
+      <div id="no-bluetooth" class="no-bluetooth-card-square mdl-card
+      mdl-shadow--2dp" style="display:none">
+      <div class="mdl-card__title mdl-card--expand">
+        <h2 class="mdl-card__title-text">No Web Bluetooth</h2>
+      </div>
+      <div class="mdl-card__supporting-text">
+        Please enable the Web Bluetooth API at chrome://flags/#enable-web-bluetooth
+      </div>
+      </div>
 
     <div id="step2">
       <canvas></canvas>

--- a/playbulb-candle/index.html
+++ b/playbulb-candle/index.html
@@ -19,14 +19,15 @@
       style="display:none">CONNECT</button>
 
       <div id="no-bluetooth" class="no-bluetooth-card-square mdl-card
-      mdl-shadow--2dp" style="display:none">
-      <div class="mdl-card__title mdl-card--expand">
-        <h2 class="mdl-card__title-text">No Web Bluetooth</h2>
+                                    mdl-shadow--2dp" style="display:none">
+        <div class="mdl-card__title mdl-card--expand">
+          <h2 class="mdl-card__title-text">No Web Bluetooth</h2>
+        </div>
+        <div class="mdl-card__supporting-text">
+          Please enable the Web Bluetooth API at chrome://flags/#enable-web-bluetooth
+        </div>
       </div>
-      <div class="mdl-card__supporting-text">
-        Please enable the Web Bluetooth API at chrome://flags/#enable-web-bluetooth
-      </div>
-      </div>
+    </div>
 
     <div id="step2">
       <canvas></canvas>

--- a/playbulb-candle/styles.css
+++ b/playbulb-candle/styles.css
@@ -79,8 +79,8 @@ body.connecting #loading {
   letter-spacing: -0.02em;
 }
 .no-bluetooth-card-square.mdl-card {
-  width: 320px;
-  height: 160px;
+  width: 100%;
+  min-height: 160px !important;
 }
 .no-bluetooth-card-square > .mdl-card__title {
   color: #fff;

--- a/playbulb-candle/styles.css
+++ b/playbulb-candle/styles.css
@@ -78,3 +78,11 @@ body.connecting #loading {
   border-radius: 4px;
   letter-spacing: -0.02em;
 }
+.no-bluetooth-card-square.mdl-card {
+  width: 320px;
+  height: 160px;
+}
+.no-bluetooth-card-square > .mdl-card__title {
+  color: #fff;
+  background: #c33;
+}


### PR DESCRIPTION
Also make home page links relative to make it easier to do local
development, e.g., with `python -m SimpleHTTPServer`.
