### PR TITLE
Use name prefix instead of service UUID

### DIFF
--- a/bluetooth-toy-bb8/index.html
+++ b/bluetooth-toy-bb8/index.html
@@ -264,7 +264,7 @@ limitations under the License.
           if (controlCharacteristic == null) {
             navigator.bluetooth.requestDevice({
               filters: [{
-                services: ['22bb746f-2bb0-7554-2d6f-726568705327']
+                namePrefix: 'BB'
               }]
             })
             .then(device => {


### PR DESCRIPTION
Some devices advertise a different service UUID.
