### PR TITLE
Use gatt.connect instead of connectGATT

### DIFF
--- a/heart-rate-sensor/heartRateSensor.js
+++ b/heart-rate-sensor/heartRateSensor.js
@@ -11,7 +11,7 @@
       return navigator.bluetooth.requestDevice({filters:[{services:[ 'heart_rate' ]}]})
       .then(device => {
         this.device = device;
-        return device.connectGATT();
+        return device.gatt.connect();
       })
       .then(server => {
         this.server = server;

--- a/playbulb-candle/playbulbCandle.js
+++ b/playbulb-candle/playbulbCandle.js
@@ -27,7 +27,7 @@
       return navigator.bluetooth.requestDevice(options)
       .then(device => {
         this.device = device;
-        return device.connectGATT();
+        return device.gatt.connect();
       })
       .then(server => {
         this.server = server;


### PR DESCRIPTION
The warning is shown when use connectGATT, it's deprecated.

Warning message:

> 'BluetoothDevice.connectGATT' is deprecated and will be removed in M52, around August 2016. Please use 'BluetoothDevice.gatt.connect' instead. See https://www.chromestatus.com/feature/5264933985976320 for more details.
