### PR TITLE
playbulb: Handle blow notifications

### DIFF
--- a/playbulb-candle/app.js
+++ b/playbulb-candle/app.js
@@ -3,11 +3,13 @@ var r = g = b = 255; // White by default.
 document.querySelector('#connect').addEventListener('click', function() {
   document.querySelector('#state').classList.add('connecting');
   playbulbCandle.connect()
-  .then(() => {
+  .then(_ => {
     document.querySelector('#state').classList.remove('connecting');
     document.querySelector('#state').classList.add('connected');
+    document.querySelector('#blow').textContent = '';
     return playbulbCandle.getDeviceName().then(handleDeviceName)
-    .then(() => playbulbCandle.getBatteryLevel().then(handleBatteryLevel));
+    .then(_ => playbulbCandle.getBatteryLevel().then(handleBatteryLevel))
+    .then(_ => playbulbCandle.startBlowNotifications(handleBlowNotifications));
   })
   .catch(error => {
     // TODO: Replace with toast when snackbar lands.
@@ -31,6 +33,19 @@ document.querySelector('#deviceName').addEventListener('input', function() {
     console.error('Argh!', error);
   });
 });
+
+/* Blow notifications */
+
+function handleBlowNotifications(event) {
+  let v = event.target.value;
+  if (v.byteLength == 8 &&
+      v.getUint8(1) == 0 && v.getUint8(2) == 0 && v.getUint8(3) == 0) {
+    // If r,g,b colors are 0, this means the candle is off.
+    document.querySelector('#blow').textContent = 'Candle OFF';
+  } else {
+    document.querySelector('#blow').textContent = 'Candle ON';
+  }
+}
 
 /* Color picker */
 

--- a/playbulb-candle/index.html
+++ b/playbulb-candle/index.html
@@ -57,7 +57,10 @@
         <span class="mdl-radio__label">Rainbow Fade</span>
       </label>
       </div>
-      <div id="batteryLevel"></div>
+      <div id="stats">
+        <div id="batteryLevel"></div>
+        <div id="blow"></div>
+      </div>
     </div>
     <div id="loading">
       <div class="mdl-spinner mdl-spinner--single-color mdl-js-spinner is-active"></div>

--- a/playbulb-candle/styles.css
+++ b/playbulb-candle/styles.css
@@ -55,7 +55,7 @@ body.connecting #loading {
   outline: none;
   margin: 12px 0;
 }
-#batteryLevel {
+#stats {
   background-color: #222222;
   margin: 12px 0;
   padding: 12px;

--- a/playbulb-candle/sw.js
+++ b/playbulb-candle/sw.js
@@ -1,4 +1,4 @@
-// Version 7
+// Version 8
 
 self.addEventListener('install', function(e) {
   e.waitUntil(


### PR DESCRIPTION
Blowing on your candle will actually turn it on/off thanks to a mini mic (small black hole).
And since the device actually notifies us of this, I thought it would be nice to handle this in the demo app.

I'm still not sure about when/if I should stop notifications though. I'd love your input on this. Thanks!

R=@scheib @g-ortuno @jyasskin 

![localhost-8000- nexus 5x 1](https://cloud.githubusercontent.com/assets/634478/16081508/fa4af2ae-330d-11e6-9787-a00094e41793.png)
