### PR TITLE
Clean up old caches

### DIFF
--- a/playbulb-candle/sw.js
+++ b/playbulb-candle/sw.js
@@ -1,11 +1,9 @@
-const version = "10";
-
 self.addEventListener('fetch', function(event) {
   const request = event.request;
   const url = new URL(event.request.url)
 
   event.respondWith(
-   caches.open(version).then(cache => {
+   caches.open('playbulb-candle').then(cache => {
       return cache.match(request).then(response => {
         var fetchPromise = fetch(request).then(networkResponse => {
           cache.put(request, networkResponse.clone());
@@ -19,5 +17,17 @@ self.addEventListener('fetch', function(event) {
         return response || fetchPromise;
       })
     })
+  );
+});
+
+/* Clean up old caches */
+self.addEventListener('activate', function(event) {
+  event.waitUntil(
+    caches.keys().then(cacheNames => {
+      return Promise.all(
+        cacheNames.filter(cacheName => (cacheName !== 'playbulb-candle'))
+                  .map(cacheName => caches.delete(cacheName))
+      );
+    });
   );
 });


### PR DESCRIPTION
Following up with @scheib's notes at https://github.com/WebBluetoothCG/demos/pull/46/files/0bfa4f7f7bbd8e5cc5b14299162cc34906063c42#r67991245 and https://github.com/WebBluetoothCG/demos/pull/47/files/511de8626ac54b39f531d5eb8155a4b047c643cc#r67991338, here's a patch that attempts to clean my Service Worker mess.
